### PR TITLE
Magic method to determine alias exclusion instead of a separate parameter

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -605,12 +605,6 @@ class QueryBuilder
     /**
      * Creates and adds a join to the query.
      *
-     * $alias is omitted from the clause on the following conditions:
-     *
-     * - $join matches $alias
-     * - $join is NULL or and empty string
-     * - $excludeAliases (class variable) is set to TRUE
-     *
      * <code>
      *     $qb = $conn->createQueryBuilder()
      *         ->select('u.name')
@@ -631,11 +625,13 @@ class QueryBuilder
     }
 
     /**
-     * Determines if an alias should be excluded from a JOIN clause
+     * Determines if an alias should be excluded from a JOIN clause.
+     * This can happen if $excludeAliases is set to TRUE, $join matches $alias or $alias is empty string or NULL
      *
-     * @param $join
-     * @param $alias
-     * @return bool
+     * @param string        $join      The table name to join
+     * @param string|null   $alias     The alias of the join table.
+     *
+     * @return bool TRUE if $alias should be excluded, FALSE otherwise
      */
     private function doExcludeJoinAlias($join, $alias): bool {
         return $this->excludeAliases || $join === $alias || empty($alias);
@@ -644,12 +640,6 @@ class QueryBuilder
     /**
      * Creates and adds a join to the query.
      *
-     * $alias is omitted from the clause on the following conditions:
-     *
-     * - $join matches $alias
-     * - $join is NULL or and empty string
-     * - $excludeAliases (class variable) is set to TRUE
-     *
      * <code>
      *     $qb = $conn->createQueryBuilder()
      *         ->select('u.name')
@@ -657,10 +647,10 @@ class QueryBuilder
      *         ->innerJoin('u', 'phonenumbers', 'p', 'p.is_primary = 1');
      * </code>
      *
-     * @param string $fromAlias     The alias or table name that points to a from clause.
-     * @param string|null $join     The table name to join.
-     * @param string $alias         The alias of the join table.
-     * @param string $condition     The condition for the join.
+     * @param string        $fromAlias     The alias or table name that points to a from clause.
+     * @param string        $join          The table name to join.
+     * @param string|null   $alias         The alias of the join table.
+     * @param string        $condition     The condition for the join.
      *
      * @return $this This QueryBuilder instance.
      */
@@ -682,12 +672,6 @@ class QueryBuilder
     /**
      * Creates and adds a left join to the query.
      *
-     * $alias is omitted from the clause on the following conditions:
-     *
-     * - $join matches $alias
-     * - $join is NULL or and empty string
-     * - $excludeAliases (class variable) is set to TRUE
-     *
      * <code>
      *     $qb = $conn->createQueryBuilder()
      *         ->select('u.name')
@@ -695,10 +679,10 @@ class QueryBuilder
      *         ->leftJoin('u', 'phonenumbers', 'p', 'p.is_primary = 1');
      * </code>
      *
-     * @param string $fromAlias     The alias or table name that points to a from clause.
-     * @param string $join          The table name to join.
-     * @param string $alias         The alias of the join table.
-     * @param string $condition     The condition for the join.
+     * @param string        $fromAlias     The alias or table name that points to a from clause.
+     * @param string        $join          The table name to join.
+     * @param string|null   $alias         The alias of the join table.
+     * @param string        $condition     The condition for the join.
      *
      * @return $this This QueryBuilder instance.
      */
@@ -727,10 +711,10 @@ class QueryBuilder
      *         ->rightJoin('u', 'phonenumbers', 'p', 'p.is_primary = 1');
      * </code>
      *
-     * @param string $fromAlias     The alias or table name that points to a from clause.
-     * @param string $join          The table name to join.
-     * @param string $alias         The alias of the join table.
-     * @param string $condition     The condition for the join.
+     * @param string        $fromAlias     The alias or table name that points to a from clause.
+     * @param string        $join          The table name to join.
+     * @param string|null   $alias         The alias of the join table.
+     * @param string        $condition     The condition for the join.
      *
      * @return $this This QueryBuilder instance.
      */

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -612,10 +612,10 @@ class QueryBuilder
      *         ->join('u', 'phonenumbers', 'p', 'p.is_primary = 1');
      * </code>
      *
-     * @param string $fromAlias     The alias or table name that points to a from clause.
-     * @param string $join          The table name to join.
-     * @param string $alias         The alias of the join table.
-     * @param string $condition     The condition for the join.
+     * @param string        $fromAlias     The alias or table name that points to a from clause.
+     * @param string        $join          The table name to join.
+     * @param string|null   $alias         The alias of the join table.
+     * @param string        $condition     The condition for the join.
      *
      * @return $this This QueryBuilder instance.
      */

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -605,6 +605,12 @@ class QueryBuilder
     /**
      * Creates and adds a join to the query.
      *
+     * $alias is omitted from the clause on the following conditions:
+     *
+     * - $join matches $alias
+     * - $join is NULL or and empty string
+     * - $excludeAliases (class variable) is set to TRUE
+     *
      * <code>
      *     $qb = $conn->createQueryBuilder()
      *         ->select('u.name')
@@ -616,17 +622,33 @@ class QueryBuilder
      * @param string $join          The table name to join.
      * @param string $alias         The alias of the join table.
      * @param string $condition     The condition for the join.
-     * @param bool   $excludeAlias The $alias will be set to an empty string and no check is performed on uniqueness
      *
      * @return $this This QueryBuilder instance.
      */
-    public function join($fromAlias, $join, $alias, $condition = null, $excludeAlias = false)
+    public function join($fromAlias, $join, $alias, $condition = null)
     {
-        return $this->innerJoin($fromAlias, $join, $alias, $condition, $excludeAlias);
+        return $this->innerJoin($fromAlias, $join, $alias, $condition);
+    }
+
+    /**
+     * Determines if an alias should be excluded from a JOIN clause
+     *
+     * @param $join
+     * @param $alias
+     * @return bool
+     */
+    private function doExcludeJoinAlias($join, $alias): bool {
+        return $this->excludeAliases || $join === $alias || empty($alias);
     }
 
     /**
      * Creates and adds a join to the query.
+     *
+     * $alias is omitted from the clause on the following conditions:
+     *
+     * - $join matches $alias
+     * - $join is NULL or and empty string
+     * - $excludeAliases (class variable) is set to TRUE
      *
      * <code>
      *     $qb = $conn->createQueryBuilder()
@@ -636,17 +658,15 @@ class QueryBuilder
      * </code>
      *
      * @param string $fromAlias     The alias or table name that points to a from clause.
-     * @param string $join          The table name to join.
+     * @param string|null $join     The table name to join.
      * @param string $alias         The alias of the join table.
      * @param string $condition     The condition for the join.
-     * @param bool   $excludeAlias The $alias will be set to an empty string and no check is performed on uniqueness
      *
      * @return $this This QueryBuilder instance.
      */
-    public function innerJoin($fromAlias, $join, $alias, $condition = null, $excludeAlias = false)
+    public function innerJoin($fromAlias, $join, $alias, $condition = null)
     {
-        # Exclude alias use if either class variable or given parameter is set to true
-        $excludeAlias = $this->excludeAliases || $excludeAlias;
+        $excludeAlias = $this->doExcludeJoinAlias($join, $alias);
 
         return $this->add('join', [
             $fromAlias => [
@@ -662,6 +682,12 @@ class QueryBuilder
     /**
      * Creates and adds a left join to the query.
      *
+     * $alias is omitted from the clause on the following conditions:
+     *
+     * - $join matches $alias
+     * - $join is NULL or and empty string
+     * - $excludeAliases (class variable) is set to TRUE
+     *
      * <code>
      *     $qb = $conn->createQueryBuilder()
      *         ->select('u.name')
@@ -673,14 +699,12 @@ class QueryBuilder
      * @param string $join          The table name to join.
      * @param string $alias         The alias of the join table.
      * @param string $condition     The condition for the join.
-     * @param bool   $excludeAlias The $alias will be set to an empty string and no check is performed on uniqueness
      *
      * @return $this This QueryBuilder instance.
      */
-    public function leftJoin($fromAlias, $join, $alias, $condition = null, $excludeAlias = false)
+    public function leftJoin($fromAlias, $join, $alias, $condition = null)
     {
-        # Exclude alias use if either class variable or given parameter is set to true
-        $excludeAlias = $this->excludeAliases || $excludeAlias;
+        $excludeAlias = $this->doExcludeJoinAlias($join, $alias);
 
         return $this->add('join', [
             $fromAlias => [
@@ -707,14 +731,12 @@ class QueryBuilder
      * @param string $join          The table name to join.
      * @param string $alias         The alias of the join table.
      * @param string $condition     The condition for the join.
-     * @param bool   $excludeAlias The $alias will be set to an empty string and no check is performed on uniqueness
      *
      * @return $this This QueryBuilder instance.
      */
-    public function rightJoin($fromAlias, $join, $alias, $condition = null, $excludeAlias = false)
+    public function rightJoin($fromAlias, $join, $alias, $condition = null)
     {
-        # Exclude alias use if either class variable or given parameter is set to true
-        $excludeAlias = $this->excludeAliases || $excludeAlias;
+        $excludeAlias = $this->doExcludeJoinAlias($join, $alias);
 
         return $this->add('join', [
             $fromAlias => [

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -1053,8 +1053,8 @@ class QueryBuilderTest extends TestCase {
             ->select('user.id')
             ->from('user')
             ->join('user','addresses','','addresses.user_id = user.id')
-            ->innerJoin('user','car','','car.user_id = user.id')
-            ->leftJoin('user','pet','','pet.user_id = user.id')
+            ->innerJoin('user','car',null,'car.user_id = user.id')
+            ->leftJoin('user','pet','pet','pet.user_id = user.id')
             ->rightJoin('user','child','','child.user_id = user.id');
 
         $this->assertEquals("SELECT user.id FROM user INNER JOIN addresses ON addresses.user_id = user.id INNER JOIN car ON car.user_id = user.id LEFT JOIN pet ON pet.user_id = user.id RIGHT JOIN child ON child.user_id = user.id", (string)$qb);

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -350,6 +350,19 @@ class QueryBuilderTest extends TestCase {
         self::assertEquals('SELECT u.*, p.* FROM users u ORDER BY u.name ASC, u.username DESC', (string) $qb);
     }
 
+    public function testSelectAddAddOrderByTwice() : void
+    {
+        $qb   = new QueryBuilder();
+        $expr = $qb->expr();
+
+        $qb->select('u.*', 'p.*')
+            ->from('users', 'u')
+            ->orderBy('u.name')
+            ->orderBy('u.username', 'DESC');
+
+        self::assertEquals('SELECT u.*, p.* FROM users u ORDER BY u.username DESC', (string) $qb);
+    }
+
     public function testEmptySelect() : void
     {
         $qb  = new QueryBuilder();
@@ -967,7 +980,7 @@ class QueryBuilderTest extends TestCase {
 
         $qb->select('user.id')
             ->from('user')
-            ->join('user','addresses','','addresses.user_id = user.id', true);
+            ->join('user','addresses','','addresses.user_id = user.id');
 
         $this->assertEquals("SELECT user.id FROM user INNER JOIN addresses ON addresses.user_id = user.id", (string)$qb);
     }
@@ -978,7 +991,7 @@ class QueryBuilderTest extends TestCase {
 
         $qb->select('user.id')
             ->from('user')
-            ->innerJoin('user','addresses','','addresses.user_id = user.id', true);
+            ->innerJoin('user','addresses','addresses','addresses.user_id = user.id');
 
         $this->assertEquals("SELECT user.id FROM user INNER JOIN addresses ON addresses.user_id = user.id", (string)$qb);
     }
@@ -989,7 +1002,7 @@ class QueryBuilderTest extends TestCase {
 
         $qb->select('user.id')
             ->from('user')
-            ->leftJoin('user','addresses','','addresses.user_id = user.id', true);
+            ->leftJoin('user','addresses', null ,'addresses.user_id = user.id');
 
         $this->assertEquals("SELECT user.id FROM user LEFT JOIN addresses ON addresses.user_id = user.id", (string)$qb);
     }
@@ -1000,7 +1013,7 @@ class QueryBuilderTest extends TestCase {
 
         $qb->select('user.id')
             ->from('user')
-            ->rightJoin('user','addresses','','addresses.user_id = user.id', true);
+            ->rightJoin('user','addresses','','addresses.user_id = user.id');
 
         $this->assertEquals("SELECT user.id FROM user RIGHT JOIN addresses ON addresses.user_id = user.id", (string)$qb);
     }
@@ -1011,10 +1024,10 @@ class QueryBuilderTest extends TestCase {
 
         $qb->select('user.id')
             ->from('user')
-            ->join('user','addresses','','addresses.user_id = user.id', true)
-            ->innerJoin('user','car','','car.user_id = user.id', true)
-            ->leftJoin('user','pet','','pet.user_id = user.id', true)
-            ->rightJoin('user','child','','child.user_id = user.id', true);
+            ->join('user','addresses','','addresses.user_id = user.id')
+            ->innerJoin('user','car',null,'car.user_id = user.id')
+            ->leftJoin('user','pet','pet','pet.user_id = user.id')
+            ->rightJoin('user','child',null,'child.user_id = user.id');
 
         $this->assertEquals("SELECT user.id FROM user INNER JOIN addresses ON addresses.user_id = user.id INNER JOIN car ON car.user_id = user.id LEFT JOIN pet ON pet.user_id = user.id RIGHT JOIN child ON child.user_id = user.id", (string)$qb);
     }
@@ -1027,7 +1040,7 @@ class QueryBuilderTest extends TestCase {
         $qb->setExcludeAliases()
             ->select('user.id')
             ->from('user')
-            ->leftJoin('user','addresses','','addresses.user_id = user.id', true);
+            ->leftJoin('user','addresses','','addresses.user_id = user.id');
 
         $this->assertEquals("SELECT user.id FROM user LEFT JOIN addresses ON addresses.user_id = user.id", (string)$qb);
     }


### PR DESCRIPTION
Added a magic method to determine if an alias should be excluded based on: 

- excludeAliases is set to TRUE
- `$join` matches `$alias`
- `$alias` is empty or NULL

Fixes #1
